### PR TITLE
fixing `issues` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ With the help of insightful statistics, you'll be able to better understand how 
 
 # Todo
 
-see open [issues](/issues)
+see open [issues](https://github.com/christian-fei/pomodoro.cc/issues)
 
 
 


### PR DESCRIPTION
Seems that using the link `/issues` points to `https://github.com/christian-fei/pomodoro.cc/blob/master/issues` that returns a 404.